### PR TITLE
Wrong bundle namespace on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
-        new Hackzilla\BarcodeBundle\HackzillaPasswordGeneratorBundle(),
+        new Hackzilla\Bundle\PasswordGeneratorBundle\HackzillaPasswordGeneratorBundle(),
     );
 }
 ```


### PR DESCRIPTION
Wrong bundle namespace or set on README, here is the good one to make it works.

Thanks.
