### PR TITLE
Lighten Symfony dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=5.3.2",
         "hackzilla/password-generator": "~1.0",
-        "symfony/symfony": "~2.3"
+        "symfony/framework-bundle": "~2.3",
+        "symfony/form": "~2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Some project does not use Symfony full-stack but just some parts.

Require all Symfony project is a bad things.

In your case, you just need `framework-bundle` and `form` components.

Regards