### PR TITLE
Travis improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,49 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - nightly
+  - hhvm
+
+env:
+  global:
+    - PATH="$HOME/.composer/vendor/bin:$PATH"
 
 matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env: CS_FIXER=run
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*@dev
+    - php: 5.6
+      env: SYMFONY_VERSION="3.0.x-dev as 2.8"
   allow_failures:
     - php: 7.0
+    - php: nightly
+    - php: hhvm
+    - php: hhvm-nightly
+    - env: SYMFONY_VERSION=2.8.*@dev
+    - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 before_script:
-  - composer self-update
-  - composer install
+  - composer selfupdate
+  - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
+  - composer global require phpunit/phpunit --no-update
+  - composer global update --prefer-dist --no-interaction
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
-script: phpunit
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	phpunit -c phpunit.xml.dist


### PR DESCRIPTION
In waiting of real tests (:-P), I propose some Travis impove.

In a nutshell:

* Makefile. We could use it later for another tasks
* PHP nightly build and hhvm
* Composer cache
* Sudo false and fast_finish to get faster Travis architecture
* Test all maintained Symfony versions
* Test with lowest deps
* Global install of PHPUnit

Note: You have to set up a Github token on secure `GITHUB_OAUTH_TOKEN` Travis env var. This token need no special permissions and will not appears on PR.

I'll make another proposition about CS once this PR get merged.