### PR TITLE
PHP CS fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/*
 composer.lock
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,19 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in([__DIR__])
+;
+
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    ->fixers([
+        '-psr0',
+        'newline_after_open_tag',
+        'ordered_use',
+        'long_array_syntax',
+        'php_unit_construct',
+        'php_unit_strict'
+    ])
+    ->setUsingCache(true)
+    ->finder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ cache:
 before_script:
   - composer selfupdate
   - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
-  - composer global require phpunit/phpunit --no-update
+  - composer global require phpunit/phpunit fabpot/php-cs-fixer --no-update
   - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS

--- a/Controller/GeneratorController.php
+++ b/Controller/GeneratorController.php
@@ -11,15 +11,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Password Generator controller.
- *
  */
 class GeneratorController extends Controller
 {
     /**
      * Password generator form.
      *
-     * @param Request $request
+     * @param Request     $request
      * @param string|null $mode
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function formAction(Request $request, $mode = null)
@@ -51,7 +51,7 @@ class GeneratorController extends Controller
     }
 
     /**
-     * Lookup Password Generator Service
+     * Lookup Password Generator Service.
      *
      * @param string $mode
      *
@@ -64,7 +64,7 @@ class GeneratorController extends Controller
             case 'computer':
             case 'human':
             case 'hybrid':
-                $serviceName = 'hackzilla.password_generator.' . $mode;
+                $serviceName = 'hackzilla.password_generator.'.$mode;
                 break;
 
             default:
@@ -75,10 +75,10 @@ class GeneratorController extends Controller
     }
 
     /**
-     * Figure out password generator mode
+     * Figure out password generator mode.
      *
      * @param Request $request
-     * @param string $mode
+     * @param string  $mode
      *
      * @return string
      */
@@ -101,11 +101,11 @@ class GeneratorController extends Controller
     }
 
     /**
-     * Build form
+     * Build form.
      *
      * @param PasswordGeneratorInterface $passwordGenerator
-     * @param Options $options
-     * @param string $mode
+     * @param Options                    $options
+     * @param string                     $mode
      *
      * @return \Symfony\Component\Form\Form
      */
@@ -116,5 +116,4 @@ class GeneratorController extends Controller
             'method' => 'GET',
         ));
     }
-
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -6,15 +6,14 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files
+ * This is the class that validates and merges configuration from your app/config files.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */
 class Configuration implements ConfigurationInterface
 {
-
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
@@ -23,5 +22,4 @@ class Configuration implements ConfigurationInterface
 
         return $treeBuilder;
     }
-
 }

--- a/DependencyInjection/HackzillaPasswordGeneratorExtension.php
+++ b/DependencyInjection/HackzillaPasswordGeneratorExtension.php
@@ -8,23 +8,21 @@ use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
 class HackzillaPasswordGeneratorExtension extends Extension
 {
-
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
         $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }
-
 }

--- a/Entity/Options.php
+++ b/Entity/Options.php
@@ -9,7 +9,7 @@ class Options
     private $quantity = 5;
     private $passwordGenerator;
 
-    public function __construct(PasswordGeneratorInterface & $passwordGenerator)
+    public function __construct(PasswordGeneratorInterface &$passwordGenerator)
     {
         $this->passwordGenerator = $passwordGenerator;
     }
@@ -31,6 +31,6 @@ class Options
 
     public function getQuantity()
     {
-        return (int)$this->quantity;
+        return (int) $this->quantity;
     }
 }

--- a/Form/Type/OptionType.php
+++ b/Form/Type/OptionType.php
@@ -20,7 +20,7 @@ class OptionType extends AbstractType
 
     /**
      * @param FormBuilderInterface $builder
-     * @param array $options
+     * @param array                $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -51,7 +51,7 @@ class OptionType extends AbstractType
         $builder->add(
             $builder->create(strtolower($key), 'text', array(
                 'data' => $option->getValue(),
-                'label' => 'OPTION_' . $key,
+                'label' => 'OPTION_'.$key,
                 'required' => false,
             ))
         );
@@ -63,7 +63,7 @@ class OptionType extends AbstractType
             $builder->create(strtolower($key), 'checkbox', array(
                 'value' => 1,
                 'data' => $option->getValue(),
-                'label' => 'OPTION_' . $key,
+                'label' => 'OPTION_'.$key,
                 'required' => false,
             ))
         );
@@ -74,7 +74,7 @@ class OptionType extends AbstractType
         $builder->add(
             $builder->create(strtolower($key), 'integer', array(
                 'data' => $option->getValue(),
-                'label' => 'OPTION_' .  $key,
+                'label' => 'OPTION_'.$key,
                 'required' => false,
             ))
         );
@@ -98,5 +98,4 @@ class OptionType extends AbstractType
     {
         return '';
     }
-
 }

--- a/HackzillaPasswordGeneratorBundle.php
+++ b/HackzillaPasswordGeneratorBundle.php
@@ -6,5 +6,4 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class HackzillaPasswordGeneratorBundle extends Bundle
 {
-
 }

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+cs:
+	php-cs-fixer fix --verbose
+
+cs_dry_run:
+	php-cs-fixer fix --verbose --dry-run
+
 test:
 	phpunit -c phpunit.xml.dist

--- a/Tests/Controller/GeneratorControllerTest.php
+++ b/Tests/Controller/GeneratorControllerTest.php
@@ -24,6 +24,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider serviceProvider
+     *
      * @param string $mode
      * @param string $check
      */
@@ -33,14 +34,14 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
 
         $container
             ->method('get')
-            ->will($this->returnCallback(function($service) {
+            ->will($this->returnCallback(function ($service) {
                 return $service;
             }));
 
         $this->_object->setContainer($container);
         $returnValue = $this->invokeMethod($this->_object, 'getPasswordGenerator', array($mode));
 
-        $this->assertEquals($check, $returnValue);
+        $this->assertSame($check, $returnValue);
     }
 
     public function modeProvider()
@@ -56,6 +57,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider modeProvider
+     *
      * @param string $mode
      * @param string $check
      */
@@ -64,7 +66,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
         $request = new \Symfony\Component\HttpFoundation\Request(array('mode' => $mode));
         $returnValue = $this->invokeMethod($this->_object, 'getMode', array($request, $mode));
 
-        $this->assertEquals($check, $returnValue);
+        $this->assertSame($check, $returnValue);
     }
 
     public function nullModeProvider()
@@ -80,6 +82,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider nullModeProvider
+     *
      * @param string $mode
      * @param string $check
      */
@@ -89,7 +92,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
 
         $returnValue = $this->invokeMethod($this->_object, 'getMode', array($request, null));
 
-        $this->assertEquals($check, $returnValue);
+        $this->assertSame($check, $returnValue);
     }
 
     /**

--- a/Tests/Entity/OptionsTest.php
+++ b/Tests/Entity/OptionsTest.php
@@ -25,14 +25,15 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider quantityProvider
+     *
      * @param mixed $quantity
-     * @param integer $check
+     * @param int   $check
      */
     public function testQuantity($quantity, $check)
     {
         $this->_object->setQuantity($quantity);
 
-        $this->assertEquals($check, $this->_object->getQuantity());
+        $this->assertSame($check, $this->_object->getQuantity());
     }
 
     public function optionProvider()
@@ -46,14 +47,15 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider optionProvider
+     *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      */
     public function testOption($key, $value)
     {
         $this->_object->{$key} = $value;
 
-        $this->assertEquals($value, $this->_object->{$key});
+        $this->assertSame($value, $this->_object->{$key});
     }
 
     public function testOptionFailure()
@@ -63,4 +65,3 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->_object->{'non_existent'};
     }
 }
- 

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 if (is_file('vendor/autoload.php')) {
     include 'vendor/autoload.php';
-} else if (is_file($autoloadFile = __DIR__ . '/../vendor/autoload.php')) {
+} elseif (is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
     require $autoloadFile;
 } else {
     throw new \LogicException('Run "composer install" to create autoloader.');


### PR DESCRIPTION
Configure and apply php-cs-fixer.

I set Symfony config and some additional rules.

CS results:

```bash
Legend: ?-unknown, I-invalid file syntax, file ignored, .-no changes, F-fixed, E-error
   1) Tests/Controller/GeneratorControllerTest.php (phpdoc_separation, function_declaration, php_unit_strict)
   2) Tests/Entity/OptionsTest.php (phpdoc_scalar, whitespacy_lines, phpdoc_separation, phpdoc_params, php_unit_strict)
   3) Tests/bootstrap.php (concat_without_spaces, elseif, eof_ending)
   4) Controller/GeneratorController.php (phpdoc_short_description, phpdoc_separation, concat_without_spaces, phpdoc_trim, phpdoc_params, braces)
   5) HackzillaPasswordGeneratorBundle.php (no_blank_lines_after_class_opening)
   6) Entity/Options.php (spaces_cast, unary_operators_spaces)
   7) Form/Type/OptionType.php (concat_without_spaces, phpdoc_params, braces)
   8) DependencyInjection/HackzillaPasswordGeneratorExtension.php (no_blank_lines_after_class_opening, phpdoc_short_description, phpdoc_inline_tag, concat_without_spaces, braces)
   9) DependencyInjection/Configuration.php (no_blank_lines_after_class_opening, phpdoc_short_description, phpdoc_inline_tag, braces)
```

Let me now if you want to change some rules, complete list here: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/1.10/README.rst