### PR TITLE
Travis improve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="3.0.x-dev as 2.8"
   allow_failures:
-    - php: 7.0
     - php: nightly
-    - php: hhvm
-    - php: hhvm-nightly
     - env: SYMFONY_VERSION=2.8.*@dev
     - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 


### PR DESCRIPTION
* HHVM nightly is not supported anymore by Travis.
* PHP 7 and HHVM works. Let's remove from allowed failure.