### PR TITLE
Introduce symfony 3.2, friendsofphp/php-cs-fixer. BC for phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 php:
@@ -5,7 +7,7 @@ php:
   - 5.6
   - 7.0
   - nightly
-  - hhvm
+  - hhvm-3.9
 
 env:
   global:
@@ -25,10 +27,20 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
     - php: 5.6
-      env: SYMFONY_VERSION="3.1.*@dev"
+      env: SYMFONY_VERSION="3.1.*"
+    - php: 5.6
+      env: SYMFONY_VERSION="3.2.*"
+    - php: 5.6
+      env: SYMFONY_VERSION="3.2.*@dev"
+    - php: 7.0
+      env: SYMFONY_VERSION="3.1.*"
+    - php: 7.0
+      env: SYMFONY_VERSION="3.2.*"
+    - php: 7.0
+      env: SYMFONY_VERSION="3.2.*@dev"
   allow_failures:
     - php: nightly
-    - env: SYMFONY_VERSION="3.1.*@dev"
+    - env: SYMFONY_VERSION="3.2.*@dev"
 
 sudo: false
 
@@ -39,7 +51,7 @@ cache:
 before_script:
   - composer selfupdate
   - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
-  - composer global require phpunit/phpunit fabpot/php-cs-fixer --no-update
+  - composer global require phpunit/phpunit friendsofphp/php-cs-fixer --no-update
   - composer global update --prefer-dist --no-interaction
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS

--- a/Tests/Controller/GeneratorControllerTest.php
+++ b/Tests/Controller/GeneratorControllerTest.php
@@ -29,7 +29,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetPasswordGenerator($mode, $check)
     {
-        $container = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('\Symfony\Component\DependencyInjection\ContainerInterface');
 
         $container
             ->method('get')
@@ -67,7 +67,7 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPasswordGeneratorException()
     {
-        $container = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('\Symfony\Component\DependencyInjection\ContainerInterface');
 
         $container
             ->method('get')
@@ -134,5 +134,25 @@ class GeneratorControllerTest extends \PHPUnit_Framework_TestCase
         $returnValue = $this->invokeMethod($this->_object, 'getMode', [$request, null]);
 
         $this->assertSame($check, $returnValue);
+    }
+
+    /**
+     * Copied from PHPUnit_Framework_TestCase for BC with phpunit < 5.4.0
+     *
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        $builder = $this->getMockBuilder($originalClassName)
+            ->disableOriginalConstructor()
+            ->disableOriginalClone()
+            ->disableArgumentCloning();
+
+        // For BC purpose. PHPUnit_Framework_MockObject_MockBuilder::disallowMockingUnknownTypes available since Release 3.2.0
+        if (true === method_exists($builder, 'disallowMockingUnknownTypes')) {
+            $builder->disallowMockingUnknownTypes();
+        }
+
+        return $builder->getMock();
     }
 }


### PR DESCRIPTION
**Symfony**
Introduce symfony version 3.2.

**php-cs-fixer**
Replace abandoned fabpot/php-cs-fixer with friendsofphp/php-cs-fixer. 

**phpunit**
Fix phpunit warnings in GeneratorControllerTest. 
BC with PHPUnit_Framework_TestCase < 5.4.0. 
BC with PHPUnit_Framework_MockObject_MockBuilder < 3.2.0.