### PR TITLE
Fix deprecation notices

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,36 +13,37 @@ parameters:
     hackzilla.password_generator.hybrid.segment_count: 4
     hackzilla.password_generator.hybrid.segment_length: 3
     hackzilla.password_generator.hybrid.segment_separator: '-'
+    hackzilla.password_generator.form.type.options.class: Hackzilla\Bundle\PasswordGeneratorBundle\Form\Type\OptionType
 
 services:
     hackzilla.password_generator.requirement:
-        class: %hackzilla.password_generator.requirement.class%
+        class: "%hackzilla.password_generator.requirement.class%"
 
     hackzilla.password_generator.dummy:
-        class: %hackzilla.password_generator.dummy.class%
+        class: "%hackzilla.password_generator.dummy.class%"
 
     hackzilla.password_generator.computer:
-        class: %hackzilla.password_generator.computer.class%
+        class: "%hackzilla.password_generator.computer.class%"
         calls:
-          - [setLength, [%hackzilla.password_generator.computer.length%]]
+          - [setLength, ["%hackzilla.password_generator.computer.length%"]]
 
     hackzilla.password_generator.human:
-        class: %hackzilla.password_generator.human.class%
+        class: "%hackzilla.password_generator.human.class%"
         calls:
-          - [setWordCount, [%hackzilla.password_generator.human.word_count%]]
-          - [setMinWordLength, [%hackzilla.password_generator.human.min_word_length%]]
-          - [setMaxWordLength, [%hackzilla.password_generator.human.max_word_length%]]
-          - [setWordSeparator, [%hackzilla.password_generator.human.word_separator%]]
-          - [setWordList, [%hackzilla.password_generator.human.word_list%]]
+          - [setWordCount, ["%hackzilla.password_generator.human.word_count%"]]
+          - [setMinWordLength, ["%hackzilla.password_generator.human.min_word_length%"]]
+          - [setMaxWordLength, ["%hackzilla.password_generator.human.max_word_length%"]]
+          - [setWordSeparator, ["%hackzilla.password_generator.human.word_separator%"]]
+          - [setWordList, ["%hackzilla.password_generator.human.word_list%"]]
 
     hackzilla.password_generator.hybrid:
-        class: %hackzilla.password_generator.hybrid.class%
+        class: "%hackzilla.password_generator.hybrid.class%"
         calls:
-          - [setSegmentCount, [%hackzilla.password_generator.hybrid.segment_count%]]
-          - [setSegmentLength, [%hackzilla.password_generator.hybrid.segment_length%]]
-          - [setSegmentSeparator, [%hackzilla.password_generator.hybrid.segment_separator%]]
+          - [setSegmentCount, ["%hackzilla.password_generator.hybrid.segment_count%"]]
+          - [setSegmentLength, ["%hackzilla.password_generator.hybrid.segment_length%"]]
+          - [setSegmentSeparator, ["%hackzilla.password_generator.hybrid.segment_separator%"]]
 
     hackzilla.password_generator.form.type.options:
-        class: Hackzilla\Bundle\PasswordGeneratorBundle\Form\Type\OptionType
+        class: "%hackzilla.password_generator.form.type.options.class%"
         tags:
             - { name: form.type }


### PR DESCRIPTION
with symfony 3.2 I got notices like this: `Not quoting the scalar "%hackzilla.password_generator.requirement.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 1x`

this PR simply add quotes and fix deprecation notices