### PR TITLE
Compatibility with Symfony 7.

### DIFF
--- a/Tests/TestKernel.php
+++ b/Tests/TestKernel.php
@@ -102,7 +102,7 @@ final class TestKernel extends Kernel
         ];
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new PublicService(), PassConfig::TYPE_OPTIMIZE);
         parent::build($container);
@@ -131,7 +131,6 @@ final class TestKernel extends Kernel
         $twigConfig = [
             'strict_variables' => '%kernel.debug%',
             'exception_controller' => null,
-            'autoescape' => 'name',
         ];
         // "default_path" configuration is available since version 3.4.
         if (version_compare(self::VERSION, '3.4', '>=')) {

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^8.0.2",
         "hackzilla/password-generator": "^1.3",
-        "symfony/framework-bundle": "^4.0|^5.0|^6.0",
-        "symfony/form": "^4.0|^5.0|^6.0",
-        "symfony/twig-bundle": "^4.0|^5.0|^6.0",
-        "symfony/serializer": "^4.0|^5.0|^6.0"
+        "symfony/framework-bundle": "^6.0|^7.0",
+        "symfony/form": "^6.0|^7.0",
+        "symfony/twig-bundle": "^6.0|^7.0",
+        "symfony/serializer": "^6.0|^7.0"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^2.0",
-        "symfony/phpunit-bridge": "^4.0|^5.0|^6.0",
+        "symfony/phpunit-bridge": "^6.0|^7.0",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {


### PR DESCRIPTION
https://github.com/hackzilla/password-generator-bundle/issues/37

Breaking changes: requires PHP >= 8.0.2 (as Symfony 6.0).

Fixes in tests (all tests pass now):
1. Added return type: `void`.
> PHP Fatal error:  Declaration of Hackzilla\Bundle\PasswordGeneratorBundle\Tests\TestKernel::build(Symfony\Component\DependencyInjection\ContainerBuilder $container) must be compatible with Symfony\Component\HttpKernel\Kernel::build(Symfony\Component\DependencyInjection\ContainerBuilder $container): void in D:\Projects\htdocs\password-generator-bundle\Tests\TestKernel.php on line 105

2. Remove `autoescape` option.
> Symfony\Component\Config\Definition\Exception\InvalidConfigurationException : Unrecognized option "autoescape" under "twig". Available options are "auto_reload", "autoescape_service", "autoescape_service_method", "base_template_class", "cache", "charset", "date", "debug", "default_path", "file_name_pattern", "form_themes", "globals", "mailer", "number_format", "optimizations", "paths", "strict_variables".
